### PR TITLE
Add Brazilian Portuguese column to typical requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ https://joompulse.com
 
 ## Skills
 
-| Skill | What it does | Typical requests |
-| --- | --- | --- |
-| [`pulse-find-exact-same-product`](skills/pulse-find-exact-same-product/SKILL.md) | Finds product listings that appear to represent the same real-world product as a reference item. | "find the same product", "match this product", "find duplicate listings" |
-| [`ml-product-analysis`](skills/ml-product-analysis/SKILL.md) | Analyzes one Mercado Livre product and its competitors, returning a product card and a ranked table of comparable products with price, estimated sales and revenue, logistics, and catalog / buy-box status. | "analyze this product", "how much does this sell", "find competing products" |
+| Skill | What it does | Typical requests | Typical requests (pt-BR) |
+| --- | --- | --- | --- |
+| [`pulse-find-exact-same-product`](skills/pulse-find-exact-same-product/SKILL.md) | Finds product listings that appear to represent the same real-world product as a reference item. | "find the same product", "match this product", "find duplicate listings" | "encontrar o mesmo produto", "achar produto igual", "encontrar anúncios duplicados" |
+| [`ml-product-analysis`](skills/ml-product-analysis/SKILL.md) | Analyzes one Mercado Livre product and its competitors, returning a product card and a ranked table of comparable products with price, estimated sales and revenue, logistics, and catalog / buy-box status. | "analyze this product", "how much does this sell", "find competing products" | "analisar este produto", "quanto vende esse produto", "encontrar produtos concorrentes" |
 
 ## How These Skills Work
 


### PR DESCRIPTION
## Summary

Adds a **Typical requests (pt-BR)** column to the skills table in `README.md`, translating the existing English example requests into Brazilian Portuguese. The skills target Mercado Livre (Brasil) sellers, so showing the example phrasings in their language makes the catalog easier to scan.

Wording matches each skill's own pt-BR triggers where defined:

| Skill | English | pt-BR |
| --- | --- | --- |
| `pulse-find-exact-same-product` | "find the same product", "match this product", "find duplicate listings" | "encontrar o mesmo produto", "achar produto igual", "encontrar anúncios duplicados" |
| `ml-product-analysis` | "analyze this product", "how much does this sell", "find competing products" | "analisar este produto", "quanto vende esse produto", "encontrar produtos concorrentes" |

Docs-only change; the English column is unchanged. `scripts/check-public-safety.sh` passes.

## Public-Safety Checklist

- [x] No credentials, tokens, keys, or secrets.
- [x] No internal filesystem paths.
- [x] No private Slack, Jira, Notion, admin, or service URLs.
- [x] No private service names or implementation details.
- [x] No customer data or private product data.
- [x] Skill directory name matches `SKILL.md` frontmatter `name`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)