### PR TITLE
Docs: add a direct add-connector link to MCP step 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To use these skills you first need to connect the **JoomPulse MCP** — it provi
 > **Get access and details:** https://joompulse.com/mcp-connector
 
 **1. Open Claude settings**
-Launch the app or open **claude.ai** and go to **Settings → Connectors**.
+Launch the app or open **claude.ai** and go to **Settings → Connectors**, or use the [Direct link to add connector](https://claude.ai/customize/connectors?modal=add-custom-connector).
 
 ![Open Claude settings → Connectors](assets/mcp/connector.png)
 


### PR DESCRIPTION
## Summary

Adds a one-click **[Direct link to add connector]** to step 1 of the *Connect the JoomPulse MCP* section, so users can jump straight to the add-custom-connector dialog instead of navigating Settings → Connectors manually. Docs-only.

## Public-Safety Checklist

- [x] No credentials, tokens, keys, or secrets.
- [x] No internal filesystem paths.
- [x] No private Slack, Jira, Notion, admin, or service URLs.
- [x] No private service names or implementation details.
- [x] No customer data or private product data.
- [x] Skill directory name matches `SKILL.md` frontmatter `name` (n/a — docs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)