### PR TITLE
Fix: remove XML-like placeholders from new-growing description

### DIFF
--- a/skills/new-growing-products-in-category/SKILL.md
+++ b/skills/new-growing-products-in-category/SKILL.md
@@ -8,8 +8,8 @@ description: >
   them as a product table with a JoomPulse link per listing. Use it when a seller
   wants fresh, promising entrants in a niche. Triggers include: "new products in
   category", "what's launching and already selling", "recent best-sellers in
-  <category>", and the pt-BR equivalents "produtos novos na categoria", "novos
-  anúncios que já vendem", "lançamentos em alta em <categoria>". Mercado Livre
+  my category", and the pt-BR equivalents "produtos novos na categoria", "novos
+  anúncios que já vendem", "lançamentos em alta na minha categoria". Mercado Livre
   (Brasil) only; sales and revenue are JoomPulse estimates, not real transactions,
   while price, rating, and review count are real history. For weak-rated but
   well-selling products to beat, use the high-demand low-quality skill; for


### PR DESCRIPTION
## Problem
The `new-growing-products-in-category` description contains literal `<category>` and `<categoria>` placeholders in its trigger examples. The skill uploader reads these as XML tags and rejects the `.zip` with:

> SKILL.md description cannot contain XML tags

## Fix
Replaced the angle-bracket placeholders with plain text in the trigger phrases:
- `recent best-sellers in <category>` → `recent best-sellers in my category`
- `lançamentos em alta em <categoria>` → `lançamentos em alta na minha categoria`

No other behavior changes. Scanned all 18 skill descriptions — this was the only one containing angle brackets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)