### PR TITLE
Fix the public-safety check: avoid the word "token"

### DIFF
--- a/skills/ml-product-analysis/SKILL.md
+++ b/skills/ml-product-analysis/SKILL.md
@@ -207,7 +207,7 @@ must belong to the same marketplace.
 
 Build a clean search query from the title or photo description, plus a broadened
 fallback query. On Shopee, titles mix Portuguese, English and Chinese, so prepare
-**short tokens in both languages** instead of one long phrase.
+**short terms in both languages** instead of one long phrase.
 
 ### Step 2 — Find analogs
 
@@ -220,7 +220,7 @@ Both the keyword and photo paths feed the same analog pipeline:
      For the photo route, the image-search results play this role.
    - **Shopee:** there is **no image search and no search by meaning**.
      Comparables come from the subject's own category plus a title search — and
-     because titles mix Portuguese, English and Chinese, search **short tokens in
+     because titles mix Portuguese, English and Chinese, search **short terms in
      both languages** rather than one long phrase, then merge the hits.
 2. **Augment when recall is thin.** Optionally widen the candidate set using
    category and keyword search, or constrain to the subject's category. On Shopee,
@@ -341,7 +341,7 @@ The seller should never see a system or stack error — only a friendly next ste
   the seller to confirm.
 - **Search returns nothing:** an empty result for a niche or non-pt-BR query is
   normal — retry once with an English or broadened query, then move on. On Shopee,
-  also try short tokens in the other language before giving up. If search is
+  also try short terms in the other language before giving up. If search is
   temporarily unavailable, say so briefly and rely on the other data.
 - **No catalogue or buy-box on Shopee:** never present catalogue status, a buy-box
   winner, a buy-box price or a seller count for a Shopee item, and never map a

--- a/skills/pulse-find-exact-same-product/SKILL.md
+++ b/skills/pulse-find-exact-same-product/SKILL.md
@@ -10,7 +10,7 @@ description: >
   o mesmo produto", "anúncios duplicados", "esse produto já existe na Shopee",
   "procurar esse item na Shopee". Ask which marketplace when unclear; never mix
   the two. On Mercado Livre the shared catalogue anchors a match; Shopee has no
-  shared catalogue, so matching is a short-token title search confirmed by
+  shared catalogue, so matching is a title search on short terms, confirmed by
   brand, category and a plausible price band, and photo search is unsupported
   there.
 ---
@@ -147,10 +147,10 @@ numbers.
   widen to a title search inside the category if that set is thin.
 - **Shopee:** title search is a **literal substring match**, and item titles mix
   Portuguese, English and Chinese. So:
-  - search several **short tokens** instead of one long precise phrase — a long
+  - search several **short terms** instead of one long precise phrase — a long
     phrase typically returns nothing at all;
-  - try both the Portuguese and the English wording of the same token;
-  - **scope the search to a category**, because a short generic token on its own
+  - try both the Portuguese and the English wording of the same term;
+  - **scope the search to a category**, because a short generic term on its own
     comes back full of unrelated bundles and accessories.
 - Prefer a compact candidate set first, then broaden only when recall is clearly
   too low.
@@ -225,11 +225,11 @@ enough. Empty field → `—`; never guess or fabricate.
   whether a Mercado Livre product is also on Shopee, run the search twice and
   report the two sides separately.
 - **No image-similarity search on Shopee:** say so in one short sentence and
-  offer the token search based on your own reading of the photo instead. Never
+  offer a term search based on your own reading of the photo instead. Never
   imply a photo match was performed.
 - **Nothing found on Shopee:** an empty result is a floor, not a verdict —
   coverage includes only items with at least one lifetime sale, and a literal
-  title search misses the wordings you did not try. Offer to try other tokens
+  title search misses the wordings you did not try. Offer to try other terms
   or another category.
 - **Market data temporarily unavailable:** retry once quietly; if it is still
   down, say market data is temporarily unavailable and to try again shortly.


### PR DESCRIPTION
`main` is currently red: the public-safety grep bans **`token`** because it normally means a credential, and the Shopee title-search guidance merged in #31 used the word in its linguistic sense — "search short tokens" — tripping the check on nine lines across two skills.

Reworded to **"terms"**, which reads more naturally for search guidance anyway:

- `pulse-find-exact-same-product` — 6 occurrences
- `ml-product-analysis` — 3 occurrences

No behaviour change; the guidance is identical. `bash scripts/check-public-safety.sh` passes locally, and the description gates (≤1024 characters, no angle brackets) still pass for all skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)