### PR TITLE
Render the cards and charts inline instead of treating them as optional

### DIFF
--- a/skills/category-monitor/SKILL.md
+++ b/skills/category-monitor/SKILL.md
@@ -237,13 +237,28 @@ Shopee:
 
 ## Visualization
 
-When the client can render inline visuals, present metric cards and a
-seller-tier chart; otherwise fall back to the markdown tables plus text cards.
-Never block on visuals. The snapshot table (and the comparison table, when
-present) always render as markdown in the response text, and the downloadable
-file mirrors what is shown.
+**Render the visuals every time the data supports them.** As soon as the analysis
+is done, present the cards and charts described below as a **self-contained visual
+panel** — an artifact where the client renders artifacts, an inline widget where
+it renders widgets. Do not ask permission first, do not describe the panel instead
+of drawing it, and do not offer it as an optional extra: the cards and charts are
+part of the answer, not a follow-up.
 
-When inline visuals are available:
+- **Order:** the cards first, then the charts, then the written read.
+- **The data table always stays markdown in the response text**, never inside the
+  panel — the panel carries cards and charts only.
+- **The estimate disclaimer always stays in the response text** as well.
+- **Skip an individual chart when its own data threshold is not met** (each
+  threshold is stated below): a chart nobody can read is worse than no chart.
+  Skipping one chart never means skipping the panel.
+- **Only the cards and charts specified below.** Do not invent extra ones, and do
+  not promote a categorical value to a bar — a chip or plain text is the honest
+  rendering for it.
+- **If no visual surface is available at all**, fall back to the markdown table
+  plus the same figures written as text cards. Never block on visuals, and never
+  leave the answer without its numbers.
+
+The panel contains:
 
 - **Cards:** estimated sales, number of products and number of active sellers,
   plus the concentration figure as a value or small bar — labelled
@@ -263,8 +278,8 @@ When inline visuals are available:
   simple line across those periods.
 
 Presentation rules: column headers are words, never a bare "Δ" symbol; show the
-color-dot legend only when those dots appear (the comparison table); render a
-chart only when the data supports it.
+color-dot legend only when those dots appear (the comparison table); and the
+downloadable file mirrors what is shown.
 
 ## Notes & Guardrails
 

--- a/skills/category-opportunity-index/SKILL.md
+++ b/skills/category-opportunity-index/SKILL.md
@@ -259,14 +259,28 @@ There is no JoomPulse category dashboard link for Shopee, so never invent one.
 
 ## Visualization
 
-When the client can render inline visuals, present the opportunity badge,
-metric cards, and the appropriate charts; otherwise fall back to a markdown
-table plus text cards. Never block on visuals — if the rich-visual path is
-unavailable for any reason, render the markdown fallback. The monthly indicators
-table always renders as markdown in the response text, on every surface, and the
-⚠️ estimate disclaimer always stays in the text.
+**Render the visuals every time the data supports them.** As soon as the analysis
+is done, present the cards and charts described below as a **self-contained visual
+panel** — an artifact where the client renders artifacts, an inline widget where
+it renders widgets. Do not ask permission first, do not describe the panel instead
+of drawing it, and do not offer it as an optional extra: the cards and charts are
+part of the answer, not a follow-up.
 
-When inline visuals are available, present in one panel:
+- **Order:** the cards first, then the charts, then the written read.
+- **The data table always stays markdown in the response text**, never inside the
+  panel — the panel carries cards and charts only.
+- **The estimate disclaimer always stays in the response text** as well.
+- **Skip an individual chart when its own data threshold is not met** (each
+  threshold is stated below): a chart nobody can read is worse than no chart.
+  Skipping one chart never means skipping the panel.
+- **Only the cards and charts specified below.** Do not invent extra ones, and do
+  not promote a categorical value to a bar — a chip or plain text is the honest
+  rendering for it.
+- **If no visual surface is available at all**, fall back to the markdown table
+  plus the same figures written as text cards. Never block on visuals, and never
+  leave the answer without its numbers.
+
+The panel contains:
 
 - **Opportunity badge** at the top: Alta 🟢 / Média 🟡 / Baixa 🔴 (show `—` if
   missing), with the marketplace and the reference month.
@@ -298,14 +312,6 @@ border). Any change or difference column uses a word as its header ("Variação"
 or "Era | Agora"), never a bare "Δ" symbol. Show a 🟢/🔴/🆕 legend only on a run
 where those symbols actually appear — never on a first or baseline run. Render a
 chart only when the underlying data supports it, and skip it otherwise.
-
-On a text-only surface, render the same information as markdown and text: the
-badge as a heading line, the five metrics as the indicators table or text cards,
-the trend as one short line describing the ~12-month direction (Mercado Livre
-only, and only when there are at least about six months of history), the
-concentration as a text value under its own marketplace's label (for example
-`Monopolização: 38% (baixa — bom)` on Mercado Livre), and the seasonality as a
-text chip line on Mercado Livre only.
 
 ## Notes & Guardrails
 

--- a/skills/fast-growing-international-products/SKILL.md
+++ b/skills/fast-growing-international-products/SKILL.md
@@ -210,12 +210,28 @@ Shopee:
 
 ## Visualization
 
-When the client can render inline visuals, present metric cards and a chart;
-otherwise fall back to the markdown table plus text cards. Never block on visuals.
-The product table always renders as markdown, on every surface, and the ⚠️
-disclaimer always stays in the text.
+**Render the visuals every time the data supports them.** As soon as the analysis
+is done, present the cards and charts described below as a **self-contained visual
+panel** — an artifact where the client renders artifacts, an inline widget where
+it renders widgets. Do not ask permission first, do not describe the panel instead
+of drawing it, and do not offer it as an optional extra: the cards and charts are
+part of the answer, not a follow-up.
 
-When inline visuals are available:
+- **Order:** the cards first, then the charts, then the written read.
+- **The data table always stays markdown in the response text**, never inside the
+  panel — the panel carries cards and charts only.
+- **The estimate disclaimer always stays in the response text** as well.
+- **Skip an individual chart when its own data threshold is not met** (each
+  threshold is stated below): a chart nobody can read is worse than no chart.
+  Skipping one chart never means skipping the panel.
+- **Only the cards and charts specified below.** Do not invent extra ones, and do
+  not promote a categorical value to a bar — a chip or plain text is the honest
+  rendering for it.
+- **If no visual surface is available at all**, fall back to the markdown table
+  plus the same figures written as text cards. Never block on visuals, and never
+  leave the answer without its numbers.
+
+The panel contains:
 
 - **Three cards:** number of products in the shortlist (top-N), number of distinct
   categories represented, and average ticket.
@@ -225,10 +241,10 @@ When inline visuals are available:
   the most fast-growing international products. Render charts only when there are
   enough items (skip under about four).
 
-Presentation rules: render a chart only when the data supports it; any change
-column uses a word header, never a bare "Δ". If you show Mercado Livre seller
-medals as colored chips, use the standard palette. On Shopee there are no medals
-— write the shop tier as plain text and never colour it as a rung on a ladder.
+Presentation rules: any change column uses a word header, never a bare "Δ". If
+you show Mercado Livre seller medals as colored chips, use the standard palette.
+On Shopee there are no medals — write the shop tier as plain text and never
+colour it as a rung on a ladder.
 
 ## Notes & Guardrails
 

--- a/skills/growing-leaf-category-tracker/SKILL.md
+++ b/skills/growing-leaf-category-tracker/SKILL.md
@@ -190,12 +190,28 @@ Shopee:
 
 ## Visualization
 
-When the client can render inline visuals, present metric cards and a chart;
-otherwise fall back to the markdown table plus text cards. Never block on visuals.
-The ranking table always renders as markdown in the response text, on every
-surface, and the ⚠️ disclaimer always stays in the text.
+**Render the visuals every time the data supports them.** As soon as the analysis
+is done, present the cards and charts described below as a **self-contained visual
+panel** — an artifact where the client renders artifacts, an inline widget where
+it renders widgets. Do not ask permission first, do not describe the panel instead
+of drawing it, and do not offer it as an optional extra: the cards and charts are
+part of the answer, not a follow-up.
 
-When inline visuals are available:
+- **Order:** the cards first, then the charts, then the written read.
+- **The data table always stays markdown in the response text**, never inside the
+  panel — the panel carries cards and charts only.
+- **The estimate disclaimer always stays in the response text** as well.
+- **Skip an individual chart when its own data threshold is not met** (each
+  threshold is stated below): a chart nobody can read is worse than no chart.
+  Skipping one chart never means skipping the panel.
+- **Only the cards and charts specified below.** Do not invent extra ones, and do
+  not promote a categorical value to a bar — a chip or plain text is the honest
+  rendering for it.
+- **If no visual surface is available at all**, fall back to the markdown table
+  plus the same figures written as text cards. Never block on visuals, and never
+  leave the answer without its numbers.
+
+The panel contains:
 
 - **Three cards:** number of growing niches found, the single fastest-growing
   niche (name + growth %), and the average growth across the shortlist.

--- a/skills/high-demand-low-quality-finder/SKILL.md
+++ b/skills/high-demand-low-quality-finder/SKILL.md
@@ -238,10 +238,28 @@ Shopee:
 
 ## Visualization
 
-When the client can render inline visuals, present metric cards and a chart on top
-of the markdown table — never instead of it. The product table always renders as
-markdown. Otherwise, fall back to plain text: the cards as text lines and the
-table as markdown, with no chart.
+**Render the visuals every time the data supports them.** As soon as the analysis
+is done, present the cards and charts described below as a **self-contained visual
+panel** — an artifact where the client renders artifacts, an inline widget where
+it renders widgets. Do not ask permission first, do not describe the panel instead
+of drawing it, and do not offer it as an optional extra: the cards and charts are
+part of the answer, not a follow-up.
+
+- **Order:** the cards first, then the charts, then the written read.
+- **The data table always stays markdown in the response text**, never inside the
+  panel — the panel carries cards and charts only.
+- **The estimate disclaimer always stays in the response text** as well.
+- **Skip an individual chart when its own data threshold is not met** (each
+  threshold is stated below): a chart nobody can read is worse than no chart.
+  Skipping one chart never means skipping the panel.
+- **Only the cards and charts specified below.** Do not invent extra ones, and do
+  not promote a categorical value to a bar — a chip or plain text is the honest
+  rendering for it.
+- **If no visual surface is available at all**, fall back to the markdown table
+  plus the same figures written as text cards. Never block on visuals, and never
+  leave the answer without its numbers.
+
+The panel contains:
 
 **Metric cards (three):**
 

--- a/skills/ml-product-analysis/SKILL.md
+++ b/skills/ml-product-analysis/SKILL.md
@@ -207,7 +207,7 @@ must belong to the same marketplace.
 
 Build a clean search query from the title or photo description, plus a broadened
 fallback query. On Shopee, titles mix Portuguese, English and Chinese, so prepare
-**short tokens in both languages** instead of one long phrase.
+**short terms in both languages** instead of one long phrase.
 
 ### Step 2 — Find analogs
 
@@ -220,7 +220,7 @@ Both the keyword and photo paths feed the same analog pipeline:
      For the photo route, the image-search results play this role.
    - **Shopee:** there is **no image search and no search by meaning**.
      Comparables come from the subject's own category plus a title search — and
-     because titles mix Portuguese, English and Chinese, search **short tokens in
+     because titles mix Portuguese, English and Chinese, search **short terms in
      both languages** rather than one long phrase, then merge the hits.
 2. **Augment when recall is thin.** Optionally widen the candidate set using
    category and keyword search, or constrain to the subject's category. On Shopee,
@@ -341,7 +341,7 @@ The seller should never see a system or stack error — only a friendly next ste
   the seller to confirm.
 - **Search returns nothing:** an empty result for a niche or non-pt-BR query is
   normal — retry once with an English or broadened query, then move on. On Shopee,
-  also try short tokens in the other language before giving up. If search is
+  also try short terms in the other language before giving up. If search is
   temporarily unavailable, say so briefly and rely on the other data.
 - **No catalogue or buy-box on Shopee:** never present catalogue status, a buy-box
   winner, a buy-box price or a seller count for a Shopee item, and never map a

--- a/skills/new-growing-products-in-category/SKILL.md
+++ b/skills/new-growing-products-in-category/SKILL.md
@@ -232,11 +232,28 @@ Shopee:
 
 ## Visualization
 
-When the client can render inline visuals, present metric cards and, when the
-data supports it, a bar chart above the markdown table; otherwise present a
-short markdown cards block (or a tiny two-column Métrica | Valor table) plus
-text. **The product table always renders as markdown**, never inside a widget —
-it is the main deliverable.
+**Render the visuals every time the data supports them.** As soon as the analysis
+is done, present the cards and charts described below as a **self-contained visual
+panel** — an artifact where the client renders artifacts, an inline widget where
+it renders widgets. Do not ask permission first, do not describe the panel instead
+of drawing it, and do not offer it as an optional extra: the cards and charts are
+part of the answer, not a follow-up.
+
+- **Order:** the cards first, then the charts, then the written read.
+- **The data table always stays markdown in the response text**, never inside the
+  panel — the panel carries cards and charts only.
+- **The estimate disclaimer always stays in the response text** as well.
+- **Skip an individual chart when its own data threshold is not met** (each
+  threshold is stated below): a chart nobody can read is worse than no chart.
+  Skipping one chart never means skipping the panel.
+- **Only the cards and charts specified below.** Do not invent extra ones, and do
+  not promote a categorical value to a bar — a chip or plain text is the honest
+  rendering for it.
+- **If no visual surface is available at all**, fall back to the markdown table
+  plus the same figures written as text cards. Never block on visuals, and never
+  leave the answer without its numbers.
+
+The panel contains:
 
 - **Summary cards** over the surviving listings:
   - **Produtos novos encontrados** — how many listings survived the filters.

--- a/skills/popular-international-products/SKILL.md
+++ b/skills/popular-international-products/SKILL.md
@@ -201,12 +201,28 @@ Shopee:
 
 ## Visualization
 
-When the client can render inline visuals, present metric cards and a chart;
-otherwise fall back to the markdown table plus text cards. Never block on visuals.
-The product table always renders as markdown, on every surface, and the ⚠️
-disclaimer always stays in the text.
+**Render the visuals every time the data supports them.** As soon as the analysis
+is done, present the cards and charts described below as a **self-contained visual
+panel** — an artifact where the client renders artifacts, an inline widget where
+it renders widgets. Do not ask permission first, do not describe the panel instead
+of drawing it, and do not offer it as an optional extra: the cards and charts are
+part of the answer, not a follow-up.
 
-When inline visuals are available:
+- **Order:** the cards first, then the charts, then the written read.
+- **The data table always stays markdown in the response text**, never inside the
+  panel — the panel carries cards and charts only.
+- **The estimate disclaimer always stays in the response text** as well.
+- **Skip an individual chart when its own data threshold is not met** (each
+  threshold is stated below): a chart nobody can read is worse than no chart.
+  Skipping one chart never means skipping the panel.
+- **Only the cards and charts specified below.** Do not invent extra ones, and do
+  not promote a categorical value to a bar — a chip or plain text is the honest
+  rendering for it.
+- **If no visual surface is available at all**, fall back to the markdown table
+  plus the same figures written as text cards. Never block on visuals, and never
+  leave the answer without its numbers.
+
+The panel contains:
 
 - **Three cards:** number of international products found, total estimated sales
   over the window in use — weekly on Mercado Livre, 30 days on Shopee — and

--- a/skills/pulse-find-exact-same-product/SKILL.md
+++ b/skills/pulse-find-exact-same-product/SKILL.md
@@ -10,7 +10,7 @@ description: >
   o mesmo produto", "anúncios duplicados", "esse produto já existe na Shopee",
   "procurar esse item na Shopee". Ask which marketplace when unclear; never mix
   the two. On Mercado Livre the shared catalogue anchors a match; Shopee has no
-  shared catalogue, so matching is a short-token title search confirmed by
+  shared catalogue, so matching is a title search on short terms, confirmed by
   brand, category and a plausible price band, and photo search is unsupported
   there.
 ---
@@ -147,10 +147,10 @@ numbers.
   widen to a title search inside the category if that set is thin.
 - **Shopee:** title search is a **literal substring match**, and item titles mix
   Portuguese, English and Chinese. So:
-  - search several **short tokens** instead of one long precise phrase — a long
+  - search several **short terms** instead of one long precise phrase — a long
     phrase typically returns nothing at all;
-  - try both the Portuguese and the English wording of the same token;
-  - **scope the search to a category**, because a short generic token on its own
+  - try both the Portuguese and the English wording of the same term;
+  - **scope the search to a category**, because a short generic term on its own
     comes back full of unrelated bundles and accessories.
 - Prefer a compact candidate set first, then broaden only when recall is clearly
   too low.
@@ -225,11 +225,11 @@ enough. Empty field → `—`; never guess or fabricate.
   whether a Mercado Livre product is also on Shopee, run the search twice and
   report the two sides separately.
 - **No image-similarity search on Shopee:** say so in one short sentence and
-  offer the token search based on your own reading of the photo instead. Never
+  offer a term search based on your own reading of the photo instead. Never
   imply a photo match was performed.
 - **Nothing found on Shopee:** an empty result is a floor, not a verdict —
   coverage includes only items with at least one lifetime sale, and a literal
-  title search misses the wordings you did not try. Offer to try other tokens
+  title search misses the wordings you did not try. Offer to try other terms
   or another category.
 - **Market data temporarily unavailable:** retry once quietly; if it is still
   down, say market data is temporarily unavailable and to try again shortly.

--- a/skills/seller-overview-tracker/SKILL.md
+++ b/skills/seller-overview-tracker/SKILL.md
@@ -273,20 +273,36 @@ to the user.
 
 ## Visualization
 
-Surface-aware. **Never block on visuals** — if anything fails, fall back to the
-markdown rendering below. The snapshot table (and the comparison table, when
-present) always render as markdown in the response text, and the downloadable file
-mirrors what is shown.
+**Render the visuals every time the data supports them.** As soon as the analysis
+is done, present the cards and charts described below as a **self-contained visual
+panel** — an artifact where the client renders artifacts, an inline widget where
+it renders widgets. Do not ask permission first, do not describe the panel instead
+of drawing it, and do not offer it as an optional extra: the cards and charts are
+part of the answer, not a follow-up.
 
-- **When the client can render inline visuals**, present **metric cards** for the
-  key current metrics — on Mercado Livre, for example estimated monthly revenue,
-  estimated monthly sales, listings, cancellation rate, and medal / reputation; on
-  Shopee, estimated monthly revenue and sales (built up from items), listings, buyer
-  rating, and shop tier. With a comparison, you may annotate each card with its
-  `era → agora` change. **Never show a card for a field that does not exist on the
-  marketplace** — no cancellation-rate or 60/365-day card on Shopee.
-- **Otherwise** (plain terminal, no visual support), output the same information as a
-  markdown table plus a short text summary. Same numbers, no visual.
+- **Order:** the cards first, then the charts, then the written read.
+- **The data table always stays markdown in the response text**, never inside the
+  panel — the panel carries cards and charts only.
+- **The estimate disclaimer always stays in the response text** as well.
+- **Skip an individual chart when its own data threshold is not met** (each
+  threshold is stated below): a chart nobody can read is worse than no chart.
+  Skipping one chart never means skipping the panel.
+- **Only the cards and charts specified below.** Do not invent extra ones, and do
+  not promote a categorical value to a bar — a chip or plain text is the honest
+  rendering for it.
+- **If no visual surface is available at all**, fall back to the markdown table
+  plus the same figures written as text cards. Never block on visuals, and never
+  leave the answer without its numbers.
+
+The panel contains:
+
+- **Metric cards** for the key current metrics — on Mercado Livre, for example
+  estimated monthly revenue, estimated monthly sales, listings, cancellation rate,
+  and medal / reputation; on Shopee, estimated monthly revenue and sales (built up
+  from items), listings, buyer rating, and shop tier. With a comparison, you may
+  annotate each card with its `era → agora` change. **Never show a card for a
+  field that does not exist on the marketplace** — no cancellation-rate or
+  60/365-day card on Shopee.
 - **Round all displayed numbers** and use **pt-BR number and currency formatting**
   (for example `R$ 1,38 mi`, `7.900`, `+1,3 p.p.`) everywhere — cards and table.
 - On Mercado Livre, use a consistent medal palette: platina = purple, ouro = amber,

--- a/skills/top-brand-position-tracker/SKILL.md
+++ b/skills/top-brand-position-tracker/SKILL.md
@@ -173,12 +173,28 @@ to see how positions moved.
 
 ## Visualization
 
-Layer a visual summary on top of the markdown table — never instead of it. The
-visuals summarize; the **ranked table is always the deliverable**. Pick the path
-by surface and never block waiting for a visual.
+**Render the visuals every time the data supports them.** As soon as the analysis
+is done, present the cards and charts described below as a **self-contained visual
+panel** — an artifact where the client renders artifacts, an inline widget where
+it renders widgets. Do not ask permission first, do not describe the panel instead
+of drawing it, and do not offer it as an optional extra: the cards and charts are
+part of the answer, not a follow-up.
 
-**When the client can render inline visuals,** present metric cards plus the bar
-chart:
+- **Order:** the cards first, then the charts, then the written read.
+- **The data table always stays markdown in the response text**, never inside the
+  panel — the panel carries cards and charts only.
+- **The estimate disclaimer always stays in the response text** as well.
+- **Skip an individual chart when its own data threshold is not met** (each
+  threshold is stated below): a chart nobody can read is worse than no chart.
+  Skipping one chart never means skipping the panel.
+- **Only the cards and charts specified below.** Do not invent extra ones, and do
+  not promote a categorical value to a bar — a chip or plain text is the honest
+  rendering for it.
+- **If no visual surface is available at all**, fall back to the markdown table
+  plus the same figures written as text cards. Never block on visuals, and never
+  leave the answer without its numbers.
+
+**The panel contains:**
 
 - **Three cards:**
   - **Marcas ativas** — the number of named brands in the ranking.
@@ -191,11 +207,6 @@ chart:
 - **Horizontal bar chart:** the top ~10 brands by **GMV estimado (semana)**,
   descending. Use a neutral single-hue ramp — this bar ranks size, it does not
   signal good or bad, so no semantic green/red.
-
-**Otherwise (a terminal or any client without inline visuals),** present the same
-three cards as a short text block (label and value per line) and let the markdown
-table itself carry the ranking. Do not attempt a visual widget; never block
-waiting for one.
 
 **Tables always render as markdown,** on every surface — the ranked table lives in
 the response text, never inside a rendered visual.

--- a/skills/top-keywords-in-my-category/SKILL.md
+++ b/skills/top-keywords-in-my-category/SKILL.md
@@ -86,11 +86,28 @@ once, in place of the estimate disclaimer.
 
 ## Visualization
 
-When the client can render inline visuals, present metric cards and a chart;
-otherwise fall back to the markdown table plus text cards. Never block on visuals.
-The keywords table always renders as markdown, on every surface.
+**Render the visuals every time the data supports them.** As soon as the analysis
+is done, present the cards and charts described below as a **self-contained visual
+panel** — an artifact where the client renders artifacts, an inline widget where
+it renders widgets. Do not ask permission first, do not describe the panel instead
+of drawing it, and do not offer it as an optional extra: the cards and charts are
+part of the answer, not a follow-up.
 
-When inline visuals are available:
+- **Order:** the cards first, then the charts, then the written read.
+- **The data table always stays markdown in the response text**, never inside the
+  panel — the panel carries cards and charts only.
+- **The estimate disclaimer always stays in the response text** as well.
+- **Skip an individual chart when its own data threshold is not met** (each
+  threshold is stated below): a chart nobody can read is worse than no chart.
+  Skipping one chart never means skipping the panel.
+- **Only the cards and charts specified below.** Do not invent extra ones, and do
+  not promote a categorical value to a bar — a chip or plain text is the honest
+  rendering for it.
+- **If no visual surface is available at all**, fall back to the markdown table
+  plus the same figures written as text cards. Never block on visuals, and never
+  leave the answer without its numbers.
+
+The panel contains:
 
 - **Three cards:** number of keywords, the number-one term, and the least-disputed
   term (the one with the fewest competing products among the top).
@@ -99,8 +116,6 @@ When inline visuals are available:
   each is are visible at a glance. Optionally flag low-competition (opportunity)
   terms. Render the chart only when there are enough keywords (skip under about
   five).
-
-Presentation rules: render a chart only when the data supports it.
 
 ## Notes & Guardrails
 

--- a/skills/top-sellers-in-category/SKILL.md
+++ b/skills/top-sellers-in-category/SKILL.md
@@ -116,13 +116,28 @@ a **Variação** column, and a **Destaques** block (maiores altas / maiores qued
 
 ## Visualization
 
-When the client can render inline visuals, present metric cards and charts;
-otherwise fall back to the markdown table plus text cards. Never block on visuals.
-The leaderboard (and the comparison, when present) always renders as markdown in
-the response text, the downloadable file mirrors it, and the ⚠️ disclaimer always
-stays in the text.
+**Render the visuals every time the data supports them.** As soon as the analysis
+is done, present the cards and charts described below as a **self-contained visual
+panel** — an artifact where the client renders artifacts, an inline widget where
+it renders widgets. Do not ask permission first, do not describe the panel instead
+of drawing it, and do not offer it as an optional extra: the cards and charts are
+part of the answer, not a follow-up.
 
-When inline visuals are available:
+- **Order:** the cards first, then the charts, then the written read.
+- **The data table always stays markdown in the response text**, never inside the
+  panel — the panel carries cards and charts only.
+- **The estimate disclaimer always stays in the response text** as well.
+- **Skip an individual chart when its own data threshold is not met** (each
+  threshold is stated below): a chart nobody can read is worse than no chart.
+  Skipping one chart never means skipping the panel.
+- **Only the cards and charts specified below.** Do not invent extra ones, and do
+  not promote a categorical value to a bar — a chip or plain text is the honest
+  rendering for it.
+- **If no visual surface is available at all**, fall back to the markdown table
+  plus the same figures written as text cards. Never block on visuals, and never
+  leave the answer without its numbers.
+
+The panel contains:
 
 - **Four cards:** number of sellers in the category (and how many have sales), the
   leader's share of the shortlist's revenue, the average monthly revenue across

--- a/skills/unbranded-products-in-category/SKILL.md
+++ b/skills/unbranded-products-in-category/SKILL.md
@@ -196,12 +196,28 @@ Shopee:
 
 ## Visualization
 
-When the client can render inline visuals, present metric cards and a chart;
-otherwise fall back to the markdown table plus text cards. Never block on visuals.
-The product table always renders as markdown in the response text, on every
-surface, and the ⚠️ disclaimer always stays in the text. No product images.
+**Render the visuals every time the data supports them.** As soon as the analysis
+is done, present the cards and charts described below as a **self-contained visual
+panel** — an artifact where the client renders artifacts, an inline widget where
+it renders widgets. Do not ask permission first, do not describe the panel instead
+of drawing it, and do not offer it as an optional extra: the cards and charts are
+part of the answer, not a follow-up.
 
-When inline visuals are available:
+- **Order:** the cards first, then the charts, then the written read.
+- **The data table always stays markdown in the response text**, never inside the
+  panel — the panel carries cards and charts only.
+- **The estimate disclaimer always stays in the response text** as well.
+- **Skip an individual chart when its own data threshold is not met** (each
+  threshold is stated below): a chart nobody can read is worse than no chart.
+  Skipping one chart never means skipping the panel.
+- **Only the cards and charts specified below.** Do not invent extra ones, and do
+  not promote a categorical value to a bar — a chip or plain text is the honest
+  rendering for it.
+- **If no visual surface is available at all**, fall back to the markdown table
+  plus the same figures written as text cards. Never block on visuals, and never
+  leave the answer without its numbers.
+
+The panel contains:
 
 - **Three cards:** number of unbranded products found — on Shopee label it as a
   lower bound — total estimated sales for the window in use, and average ticket.
@@ -210,11 +226,11 @@ When inline visuals are available:
   the chart only when there are enough products (skip it under about four), and
   never block on it.
 
-Presentation rules: render a chart only when the data supports it; any column with
-movement uses a word header, never a bare "Δ". The medal palette (platina = purple,
-ouro = amber, prata = blue, sem medalha = white with a thin border) is Mercado Livre
-only — on Shopee write the shop tier as plain text and never colour it as if it were
-a rung on a ladder.
+Presentation rules: no product images; render a chart only when the data supports
+it; any column with movement uses a word header, never a bare "Δ". The medal palette
+(platina = purple, ouro = amber, prata = blue, sem medalha = white with a thin
+border) is Mercado Livre only — on Shopee write the shop tier as plain text and
+never colour it as if it were a rung on a ladder.
 
 ## Notes & Guardrails
 

--- a/skills/uncontested-niche-finder/SKILL.md
+++ b/skills/uncontested-niche-finder/SKILL.md
@@ -300,11 +300,28 @@ Shopee:
 
 ## Visualization
 
-When the client can render inline visuals, present metric cards and, when the
-data supports it, the appropriate chart; otherwise present a short text version
-of the cards. **The product table always renders as markdown** — never inside a
-widget — so the competition signal stays legible. Render a chart only when the
-data supports it, and skip it otherwise.
+**Render the visuals every time the data supports them.** As soon as the analysis
+is done, present the cards and charts described below as a **self-contained visual
+panel** — an artifact where the client renders artifacts, an inline widget where
+it renders widgets. Do not ask permission first, do not describe the panel instead
+of drawing it, and do not offer it as an optional extra: the cards and charts are
+part of the answer, not a follow-up.
+
+- **Order:** the cards first, then the charts, then the written read.
+- **The data table always stays markdown in the response text**, never inside the
+  panel — the panel carries cards and charts only.
+- **The estimate disclaimer always stays in the response text** as well.
+- **Skip an individual chart when its own data threshold is not met** (each
+  threshold is stated below): a chart nobody can read is worse than no chart.
+  Skipping one chart never means skipping the panel.
+- **Only the cards and charts specified below.** Do not invent extra ones, and do
+  not promote a categorical value to a bar — a chip or plain text is the honest
+  rendering for it.
+- **If no visual surface is available at all**, fall back to the markdown table
+  plus the same figures written as text cards. Never block on visuals, and never
+  leave the answer without its numbers.
+
+The panel contains:
 
 **Cards** — three summary cards:
 
@@ -321,14 +338,10 @@ used — strongest uncontested niches first, each bar labelled with a short prod
 name. **Skip the bar entirely when there are fewer than four products** — show
 only the cards and the table.
 
-**Otherwise (no inline visuals)**: render the three cards as a short text block,
-one line each, and — only when there are four or more products — a tiny text list
-of the top niches by estimated revenue over that same window. **Never block on
-visuals**; if inline rendering is unavailable or fails, fall straight through to
-the markdown output. Round numbers and use pt-BR formatting (for example `R$
-1.234`, `1.234 vendas`). If you show Mercado Livre seller medals as coloured
-chips, keep the standard palette; on Shopee there are no medals, so write the
-shop tier as plain text and never colour it as a rung on a ladder.
+Round numbers and use pt-BR formatting (for example `R$ 1.234`, `1.234 vendas`).
+If you show Mercado Livre seller medals as coloured chips, keep the standard
+palette; on Shopee there are no medals, so write the shop tier as plain text and
+never colour it as a rung on a ladder.
 
 ## Notes & Guardrails
 


### PR DESCRIPTION
## The problem

Every skill that specifies visuals guarded them behind *"when the client can render inline visuals"* — and named no mechanism. Nothing in the Claude app matches that phrase, so the skill quietly took the markdown fallback and the seller never saw a card or a chart. Verified: **13 skills carry a `## Visualization` section, and none of them named a rendering mechanism.** The visuals were effectively dead on the surface most people use.

## What changed

The 13 skills that specify visuals now render them **every time the data supports them**, as a self-contained panel — an artifact where the client renders artifacts, an inline widget where it renders widgets. One canonical block, inserted byte-identically in all 13 so the behaviour cannot drift:

- **Order:** cards first, then charts, then the written read.
- The data table and the estimate disclaimer **stay in the response text**, never inside the panel.
- The panel is **not optional** and must not be described instead of drawn.
- **Skipping one chart** whose own threshold is not met never means skipping the panel.
- Where **no visual surface exists at all**, the markdown-plus-text-cards fallback still applies.

## What deliberately did not change

- **No card or chart was added, renamed or removed.** Every existing spec, data threshold ("skip under about four", "only after N accumulated runs"), palette rule and per-marketplace window label is untouched. This PR changes *when* the visuals render, not *what* they are.
- **The five skills that never specified visuals are left alone** — single-product analysis, buy-box comparison, product change monitor, same-product finder, and the copilot. Nothing was invented for them.
- Existing conventions are preserved as written: the medal palette stays Mercado Livre only (Shopee shop tiers render as plain text), change-column headers stay words rather than a bare delta symbol, the movement legend still appears only when those symbols are actually in the table, and the top-keywords skill still carries no estimate disclaimer because its data is real.

## Verification

- Only the `## Visualization` section changed in each file — the rest of every file is **byte-identical** to the base.
- The canonical block is **verbatim in all 13**.
- Spec bullets per skill before → after: identical in 12; `seller-overview-tracker` goes 4 → 3 because its old *"Otherwise (plain terminal, no visual support)"* fallback bullet is now covered by the canonical block — its metric-cards bullet survived, reworded from conditional to unconditional.
- Description gates (≤1024 characters, no angle brackets) pass for all skills; `scripts/check-public-safety.sh` passes.

> Note: this branch is based on #32, so it also carries that one-line public-safety fix. Merge #32 first and this rebases cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)