### PR TITLE
Resolve the report language from the request, not from the seller

### DIFF
--- a/skills/category-monitor/SKILL.md
+++ b/skills/category-monitor/SKILL.md
@@ -66,8 +66,11 @@ JoomPulse MCP setup before it can monitor a category.
 - **Read-only.** The skill never writes or modifies anything; it does not store
   the snapshot — the user keeps the downloadable table and brings it back next
   period.
-- **Language:** detect the seller's language and respond in it. Default to
-  pt-BR.
+- **Language:** write in the language of the message you are answering, and
+  default to pt-BR only when that is unclear. Never infer the language from the
+  store, its listings or the marketplace — those are Brazilian whatever
+  language the seller writes in, so a seller who asks in English gets the whole
+  report in English.
 - **The baseline is user-supplied.** Never claim a change without a previous
   table to compare against, and never infer or fabricate one from memory.
 
@@ -180,8 +183,16 @@ an incomplete month.
 
 ## Output
 
-Respond in the seller's language (default pt-BR). Name the marketplace the
-figures came from.
+Respond in the language of the seller's request (default pt-BR). Name the
+marketplace the figures came from.
+
+The column headers, labels and disclaimers below are written in pt-BR because
+that is the default. They are a template, not literal strings: when the seller
+writes in another language, translate all of them — the headers, row values
+such as `sim` / `não` / `ouro`, and the disclaimer — and keep the structure,
+the emoji and the `R$` money formatting, which stays the same in every language
+because the marketplace trades in reais. When the request is in English, no
+Portuguese is left anywhere in the answer.
 
 **Snapshot (always):** a markdown table `| Métrica | Valor atual |`, plus a
 downloadable `.csv` / `.xlsx` of the same data.

--- a/skills/category-opportunity-index/SKILL.md
+++ b/skills/category-opportunity-index/SKILL.md
@@ -21,13 +21,14 @@ description: >
 
 This skill answers a single question for **one** category on **Mercado Livre
 (Brasil) or Shopee Brasil**: is it worth entering? Given a marketplace and a
-category named in free text, it reads that category's **opportunity index** (low,
-medium, or high) and its current monthly market indicators — estimated revenue,
-estimated sales, sellers, listings, and average ticket — then writes a short
-pt-BR summary that interprets the opportunity level together with how
-concentrated the market is and which way it is growing. On Mercado Livre the
-summary can also draw on a year of history and a seasonality read; on Shopee
-neither exists yet, and the report says so plainly instead of guessing.
+category named in free text, it reads that category's **opportunity index**
+(low, medium, or high) and its current monthly market indicators — estimated
+revenue, estimated sales, sellers, listings, and average ticket — then writes a
+short summary, in the language the seller wrote in, that interprets the
+opportunity level together with how concentrated the market is and which way it
+is growing. On Mercado Livre the summary can also draw on a year of history and
+a seasonality read; on Shopee neither exists yet, and the report says so
+plainly instead of guessing.
 
 This is a point-in-time snapshot, not a tracker. To rank the sellers inside a
 category, use the top-sellers-in-category skill. For the trending search terms
@@ -59,8 +60,11 @@ JoomPulse MCP setup before it can report a category's opportunity index.
   marketplace's own rounded sold counters refined with review movement. Use the
   matching disclaimer.
 - **Read-only.** The skill never writes or modifies anything.
-- **Language:** detect the seller's language and respond in it. Default to
-  pt-BR.
+- **Language:** write in the language of the message you are answering, and
+  default to pt-BR only when that is unclear. Never infer the language from the
+  store, its listings or the marketplace — those are Brazilian whatever
+  language the seller writes in, so a seller who asks in English gets the whole
+  report in English.
 - **Keep the workflow invisible.** The seller wants the answer, not a play-by-
   play. If one approach does not return data, switch to another quietly; only if
   every approach fails do you say one short, friendly sentence. Never fill gaps
@@ -173,13 +177,22 @@ Do not draw a trend and do not pass three points off as one: state plainly that 
 long-run trend is not available for Shopee yet, and report the snapshot plus the
 month-over-month change instead.
 
-### Step 4 — Build the report (pt-BR)
+### Step 4 — Build the report
 
-1. Lead with the **opportunity index**, prominently: 🟢 alto / 🟡 médio / 🔴
-   baixo (show `—` if it is missing), noting the marketplace, the category name
-   and level, and the month the figures describe.
+Write the whole report in the language of the message you are answering — not
+the language of the store or its listings, which are Brazilian either way.
+Every Portuguese word in this step and in Output is a pt-BR template: translate
+the badge wording, the table headers, the section labels and the disclaimer.
+Keep the emoji, the table structure and `R$` exactly as they are. When the
+message is in English, no Portuguese is left anywhere in the report.
+
+1. Lead with the **opportunity index**, prominently: 🟢 alto / 🟡 médio / 🔴 baixo
+   — pt-BR wording, translated for any other language, emoji unchanged — (show
+   `—` if it is missing), noting the marketplace, the category name and level,
+   and the month the figures describe.
 2. Show the monthly indicators table (see Output).
-3. Write a 2–4 sentence **resumo** that interprets the opportunity index
+3. Write a 2–4 sentence summary — labelled **Resumo** in pt-BR — that
+   interprets the opportunity index
    together with concentration and growth:
    - What the level means — high implies good room for new sellers; low implies
      little relative upside.
@@ -203,9 +216,17 @@ month-over-month change instead.
 
 ## Output
 
-Respond in the seller's language, default pt-BR, with no commentary about how the
-report was produced. The indicators table always renders as markdown so it shows
-cleanly in any client.
+Respond in the language of the seller's request, default pt-BR, with no
+commentary about how the report was produced. The indicators table always
+renders as markdown so it shows cleanly in any client.
+
+The column headers, labels and disclaimers below are written in pt-BR because
+that is the default. They are a template, not literal strings: when the seller
+writes in another language, translate all of them — the headers, row values
+such as `sim` / `não` / `ouro`, and the disclaimer — and keep the structure,
+the emoji and the `R$` money formatting, which stays the same in every language
+because the marketplace trades in reais. When the request is in English, no
+Portuguese is left anywhere in the answer.
 
 **Opportunity badge** — a heading line naming the marketplace, the category and
 the month the figures cover, for example:
@@ -236,6 +257,9 @@ cells show `—`.
 **Resumo** — the 2–4 sentence interpretation described in the workflow.
 
 **Disclaimer (every report) — use the variant for the marketplace you queried.**
+Each variant below carries the pt-BR wording and the English wording separated by
+` / `. Emit only the half that matches the language of the seller's request —
+never both halves and never the slash.
 
 Mercado Livre:
 

--- a/skills/fast-growing-international-products/SKILL.md
+++ b/skills/fast-growing-international-products/SKILL.md
@@ -53,7 +53,11 @@ JoomPulse MCP setup before it can find international products.
   the marketplace's own rounded sold counters refined with review movement. Use
   the matching disclaimer, and disclose the estimate caveat in every output.
 - **Read-only.** The skill never writes or modifies anything.
-- **Language:** detect the seller's language and respond in it. Default to pt-BR.
+- **Language:** write in the language of the message you are answering, and
+  default to pt-BR only when that is unclear. Never infer the language from the
+  store, its listings or the marketplace — those are Brazilian whatever
+  language the seller writes in, so a seller who asks in English gets the whole
+  report in English.
 - **Keep the workflow invisible.** Show `—` for any missing value; never fabricate.
 
 **Shopee data — what differs from Mercado Livre**
@@ -149,9 +153,18 @@ weekly ranking**. Label it plainly as a *top-by-revenue fallback*, never call it
 
 ## Output
 
-Respond in the seller's language (default pt-BR). Lead with a short line naming
-the **marketplace** you queried. The product list always renders as a markdown
-table, and **includes a Category column** (the cross-category differentiator).
+Respond in the language of the seller's request (default pt-BR). Lead with a
+short line naming the **marketplace** you queried. The product list always
+renders as a markdown table, and **includes a Category column** (the
+cross-category differentiator).
+
+The column headers, labels and disclaimers below are written in pt-BR because
+that is the default. They are a template, not literal strings: when the seller
+writes in another language, translate all of them — the headers, row values
+such as `sim` / `não` / `ouro`, and the disclaimer — and keep the structure,
+the emoji and the `R$` money formatting, which stays the same in every language
+because the marketplace trades in reais. When the request is in English, no
+Portuguese is left anywhere in the answer.
 
 **Product table (Mercado Livre):**
 

--- a/skills/growing-leaf-category-tracker/SKILL.md
+++ b/skills/growing-leaf-category-tracker/SKILL.md
@@ -62,7 +62,11 @@ JoomPulse MCP setup before it can find growing niches.
   own rounded sold counters refined with review movement. Use the matching
   disclaimer.
 - **Read-only.** The skill never writes or modifies anything.
-- **Language:** detect the seller's language and respond in it. Default to pt-BR.
+- **Language:** write in the language of the message you are answering, and
+  default to pt-BR only when that is unclear. Never infer the language from the
+  store, its listings or the marketplace — those are Brazilian whatever
+  language the seller writes in, so a seller who asks in English gets the whole
+  report in English.
 - **Keep the workflow invisible.** Surface the answer, not the steps. Never fill
   gaps from general knowledge; show `—` for any missing value.
 
@@ -155,11 +159,20 @@ the most recent month with the one before it and read nothing longer-run into it
 
 ## Output
 
-Respond in the seller's language (default pt-BR), with no commentary about how the
-result was produced. Lead with a short line naming the **marketplace**, the parent
-category, the **level the ranking is at**, and the month the figures describe. On
-Shopee that line also says plainly that niches deeper than the third level are
-folded into their level-3 ancestor and cannot be separated here.
+Respond in the language of the seller's request (default pt-BR), with no
+commentary about how the result was produced. Lead with a short line naming the
+**marketplace**, the parent category, the **level the ranking is at**, and the
+month the figures describe. On Shopee that line also says plainly that niches
+deeper than the third level are folded into their level-3 ancestor and cannot
+be separated here.
+
+The column headers, labels and disclaimers below are written in pt-BR because
+that is the default. They are a template, not literal strings: when the seller
+writes in another language, translate all of them — the headers, row values
+such as `sim` / `não` / `ouro`, and the disclaimer — and keep the structure,
+the emoji and the `R$` money formatting, which stays the same in every language
+because the marketplace trades in reais. When the request is in English, no
+Portuguese is left anywhere in the answer.
 
 The ranking always renders as a markdown table:
 

--- a/skills/high-demand-low-quality-finder/SKILL.md
+++ b/skills/high-demand-low-quality-finder/SKILL.md
@@ -59,7 +59,11 @@ JoomPulse MCP setup before it can find opportunities.
   historical listing data, on Shopee from the marketplace's own rounded sold
   counters refined with review movement. Use the matching disclaimer.
 - **Read-only.** The skill does not sign in as the seller or modify any listing.
-- **Language:** detect the seller's language and respond in it. Default to pt-BR.
+- **Language:** write in the language of the message you are answering, and
+  default to pt-BR only when that is unclear. Never infer the language from the
+  store, its listings or the marketplace — those are Brazilian whatever
+  language the seller writes in, so a seller who asks in English gets the whole
+  report in English.
 - **Keep the workflow invisible.** The seller wants the answer, not a play-by-
   play. If one approach does not return data, switch to another quietly; only if
   every approach fails do you say one short, friendly sentence.
@@ -159,9 +163,17 @@ needs. Pull a generous set so the filters have room to work.
 
 ## Output
 
-Respond in the seller's language. Present the result with no commentary about how
-it was produced. The product table always renders as markdown so it displays
-cleanly in any client.
+Respond in the language of the seller's request. Present the result with no
+commentary about how it was produced. The product table always renders as
+markdown so it displays cleanly in any client.
+
+The column headers, labels and disclaimers below are written in pt-BR because
+that is the default. They are a template, not literal strings: when the seller
+writes in another language, translate all of them — the headers, row values
+such as `sim` / `não` / `ouro`, and the disclaimer — and keep the structure,
+the emoji and the `R$` money formatting, which stays the same in every language
+because the marketplace trades in reais. When the request is in English, no
+Portuguese is left anywhere in the answer.
 
 Lead with a short intro line naming the **marketplace**, the category and the
 rating threshold actually applied.

--- a/skills/ml-product-analysis/SKILL.md
+++ b/skills/ml-product-analysis/SKILL.md
@@ -58,8 +58,11 @@ JoomPulse MCP setup before it can analyze a product or find competitors.
 - **Prices are marketplace prices only.** Do not surface sourcing prices,
   margins, or profit figures.
 - **Read-only.** The skill does not sign in as the seller or modify any listing.
-- **Language:** detect the seller's language and respond in it. Default to
-  pt-BR.
+- **Language:** write in the language of the message you are answering, and
+  default to pt-BR only when that is unclear. Never infer the language from the
+  store, its listings or the marketplace — those are Brazilian whatever
+  language the seller writes in, so a seller who asks in English gets the whole
+  report in English.
 - **Keep the workflow invisible.** The seller wants the answer, not a play-by-
   play. Do the analysis quietly and present only the result. If one approach to
   finding the product or its competitors does not work, switch to another
@@ -242,8 +245,16 @@ Both the keyword and photo paths feed the same analog pipeline:
 
 ## Output
 
-Respond in the seller's language. The visible reply contains only the result, in
-this order, with no commentary about how it was produced:
+Respond in the language of the seller's request. The visible reply contains
+only the result, in this order, with no commentary about how it was produced:
+
+The column headers, labels and disclaimers below are written in pt-BR because
+that is the default. They are a template, not literal strings: when the seller
+writes in another language, translate all of them — the headers, row values
+such as `sim` / `não` / `ouro`, and the disclaimer — and keep the structure,
+the emoji and the `R$` money formatting, which stays the same in every language
+because the marketplace trades in reais. When the request is in English, no
+Portuguese is left anywhere in the answer.
 
 1. An optional one-line framing sentence, naming the **marketplace**.
 2. The subject product card.
@@ -287,11 +298,12 @@ rating, reviews, favourites, cross-border shipping, photo count, shop tier, and 
 links column holding the item and shop links on Shopee. **No catalogue, buy-box
 or seller-count columns** — drop them, do not leave them blank.
 
-You may translate the column headers and card labels into the seller's language.
-Note that the sales windows are **not** the same on the two marketplaces: Mercado
-Livre reports weekly and monthly figures, Shopee reports 30-day figures only —
-label the Shopee columns as 30 days and never present a 30-day figure under a
-weekly or monthly heading. Empty field → `—`; never guess or fabricate.
+You may translate the column headers and card labels into the language of the
+seller's request. Note that the sales windows are **not** the same on the two
+marketplaces: Mercado Livre reports weekly and monthly figures, Shopee reports
+30-day figures only — label the Shopee columns as 30 days and never present a
+30-day figure under a weekly or monthly heading. Empty field → `—`; never guess
+or fabricate.
 
 **Disclaimer (every report) — use the variant for the marketplace you queried.**
 

--- a/skills/my-product-vs-catalog/SKILL.md
+++ b/skills/my-product-vs-catalog/SKILL.md
@@ -19,9 +19,10 @@ description: >
 # Mercado Livre — My Product vs. Catalog (Buy-Box Competitiveness)
 
 This skill compares the seller's **own** Mercado Livre (Brasil) listing against
-**the available competing listings of the same catalog product** — the sellers competing
-for the same buy-box — and tells the seller, in pt-BR, where they win, where they
-lose, and **what to fix first** to win the buy-box and convert more.
+**the available competing listings of the same catalog product** — the sellers
+competing for the same buy-box — and tells the seller, in the language of their
+request, where they win, where they lose, and **what to fix first** to win the
+buy-box and convert more.
 
 Given a product by a Mercado Livre link, a JoomPulse link, a Mercado Livre listing
 identifier, or a catalog product identifier, it identifies the seller's listing and
@@ -63,7 +64,11 @@ JoomPulse MCP setup before it can compare a listing against its catalog.
   review count, logistics, and seller attributes are real Mercado Livre data — say
   so, it is a strength of the report.
 - **Read-only.** The skill does not sign in as the seller or modify any listing.
-- **Language:** detect the seller's language and respond in it. Default to pt-BR.
+- **Language:** write in the language of the message you are answering, and
+  default to pt-BR only when that is unclear. Never infer the language from the
+  store, its listings or the marketplace — those are Brazilian whatever
+  language the seller writes in, so a seller who asks in English gets the whole
+  report in English.
 - **Keep the workflow invisible.** The seller wants the answer, not a play-by-play.
   If one lookup returns nothing, switch approaches quietly; only if everything fails
   do you say one short, friendly sentence.
@@ -116,7 +121,16 @@ Each parameter gets one status, with a colour marker so it reads at a glance:
 
 ## Output
 
-Respond in pt-BR, leading with the verdict:
+Respond in the language of the seller's request, default pt-BR, leading with
+the verdict:
+
+The column headers, labels and disclaimers below are written in pt-BR because
+that is the default. They are a template, not literal strings: when the seller
+writes in another language, translate all of them — the headers, row values
+such as `sim` / `não` / `ouro`, and the disclaimer — and keep the structure,
+the emoji and the `R$` money formatting, which stays the same in every language
+because the marketplace trades in reais. When the request is in English, no
+Portuguese is left anywhere in the answer.
 
 1. **Veredito** — two to four sentences: where the seller wins, where they lose,
    their buy-box position, and the single top priority.

--- a/skills/new-growing-products-in-category/SKILL.md
+++ b/skills/new-growing-products-in-category/SKILL.md
@@ -55,7 +55,11 @@ JoomPulse MCP setup before it can find new growing products in a category.
   historical listing data, on Shopee from the marketplace's own rounded sold
   counters refined with review movement. Use the matching disclaimer.
 - **Read-only.** The skill does not sign in as the seller or modify any listing.
-- **Language:** detect the seller's language and respond in it. Default to pt-BR.
+- **Language:** write in the language of the message you are answering, and
+  default to pt-BR only when that is unclear. Never infer the language from the
+  store, its listings or the marketplace — those are Brazilian whatever
+  language the seller writes in, so a seller who asks in English gets the whole
+  report in English.
 - **Keep the workflow invisible.** The seller wants the answer, not a play-by-
   play. If one approach does not return data, switch to another quietly; only if
   every approach fails do you say one short, friendly sentence.
@@ -153,8 +157,17 @@ numbers.
 
 ## Output
 
-Respond in the seller's language. Present the result with no commentary about how
-it was produced. Use plain markdown so it renders cleanly in any client.
+Respond in the language of the seller's request. Present the result with no
+commentary about how it was produced. Use plain markdown so it renders cleanly
+in any client.
+
+The column headers, labels and disclaimers below are written in pt-BR because
+that is the default. They are a template, not literal strings: when the seller
+writes in another language, translate all of them — the headers, row values
+such as `sim` / `não` / `ouro`, and the disclaimer — and keep the structure,
+the emoji and the `R$` money formatting, which stays the same in every language
+because the marketplace trades in reais. When the request is in English, no
+Portuguese is left anywhere in the answer.
 
 Lead with a short intro line naming the **marketplace**, the category and the
 three thresholds actually applied, and state that the listings are **ranked by
@@ -205,8 +218,8 @@ marketplaces: Mercado Livre reports weekly and monthly figures, Shopee reports
 
 Empty field → `—`; never guess or fabricate. Below the table, list the item codes
 explicitly so they are easy to copy — as clickable JoomPulse links on Mercado
-Livre, as Shopee item links on Shopee. You may translate the column headers into
-the seller's language.
+Livre, as Shopee item links on Shopee. You may translate the column headers
+into the language of the seller's request.
 
 **Disclaimer (every report) — use the variant for the marketplace you queried.**
 
@@ -286,9 +299,10 @@ The seller should never see a system or stack error — only a friendly next ste
 
 - **No listings survive the filters:** say that no new listings currently match
   these thresholds in this category, and offer to relax them (for example, a
-  larger day-on-air window or a lower monthly-sales floor). Keep it in pt-BR.
-  On Shopee, add that the list is a lower bound — only items with at least one
-  lifetime sale are tracked — so an empty result is not proof the niche is quiet.
+  larger day-on-air window or a lower monthly-sales floor). Keep it in the
+  language of the seller's request. On Shopee, add that the list is a lower
+  bound — only items with at least one lifetime sale are tracked — so an empty
+  result is not proof the niche is quiet.
 - **Category not found or ambiguous name:** list the candidate categories (name
   and level) and ask the user to pick one. If nothing matches, check the other
   marketplace before saying the category does not exist.

--- a/skills/popular-international-products/SKILL.md
+++ b/skills/popular-international-products/SKILL.md
@@ -53,7 +53,11 @@ JoomPulse MCP setup before it can find international products.
   marketplace's own rounded sold counters refined with review movement. Use the
   matching disclaimer.
 - **Read-only.** The skill never writes or modifies anything.
-- **Language:** detect the seller's language and respond in it. Default to pt-BR.
+- **Language:** write in the language of the message you are answering, and
+  default to pt-BR only when that is unclear. Never infer the language from the
+  store, its listings or the marketplace — those are Brazilian whatever
+  language the seller writes in, so a seller who asks in English gets the whole
+  report in English.
 - **Keep the workflow invisible.** Surface the answer, not the steps. Show `—` for
   any missing value; never fabricate one.
 
@@ -149,10 +153,18 @@ Keep the shortlist (about 10).
 
 ## Output
 
-Respond in the seller's language (default pt-BR). Lead with a short intro line
-naming the **marketplace** and the category, the fast-growth rule you applied, and
-what "international" means here. The product list always renders as a markdown
-table.
+Respond in the language of the seller's request (default pt-BR). Lead with a
+short intro line naming the **marketplace** and the category, the fast-growth
+rule you applied, and what "international" means here. The product list always
+renders as a markdown table.
+
+The column headers, labels and disclaimers below are written in pt-BR because
+that is the default. They are a template, not literal strings: when the seller
+writes in another language, translate all of them — the headers, row values
+such as `sim` / `não` / `ouro`, and the disclaimer — and keep the structure,
+the emoji and the `R$` money formatting, which stays the same in every language
+because the marketplace trades in reais. When the request is in English, no
+Portuguese is left anywhere in the answer.
 
 **Mercado Livre:**
 

--- a/skills/product-change-monitor/SKILL.md
+++ b/skills/product-change-monitor/SKILL.md
@@ -61,7 +61,11 @@ JoomPulse MCP setup before it can monitor a product's changes.
   historical listing data, on Shopee from the marketplace's own rounded sold
   counters refined with review movement. Use the matching disclaimer.
 - **Read-only.** The skill does not sign in as the seller or modify any listing.
-- **Language:** detect the seller's language and respond in it. Default to pt-BR.
+- **Language:** write in the language of the message you are answering, and
+  default to pt-BR only when that is unclear. Never infer the language from the
+  store, its listings or the marketplace — those are Brazilian whatever
+  language the seller writes in, so a seller who asks in English gets the whole
+  report in English.
 - **Keep the workflow invisible.** The seller wants the answer, not a play-by-
   play. If one approach does not return data, switch to another quietly; only if
   every approach fails do you say one short, friendly sentence.
@@ -186,8 +190,17 @@ directly — ask for a Mercado Livre, Shopee or JoomPulse link or identifier.
 
 ## Output
 
-Respond in the seller's language. Present the result with no commentary about how
-it was produced. Use plain markdown so it renders cleanly in any client.
+Respond in the language of the seller's request. Present the result with no
+commentary about how it was produced. Use plain markdown so it renders cleanly
+in any client.
+
+The column headers, labels and disclaimers below are written in pt-BR because
+that is the default. They are a template, not literal strings: when the seller
+writes in another language, translate all of them — the headers, row values
+such as `sim` / `não` / `ouro`, and the disclaimer — and keep the structure,
+the emoji and the `R$` money formatting, which stays the same in every language
+because the marketplace trades in reais. When the request is in English, no
+Portuguese is left anywhere in the answer.
 
 Lead with a short line naming the **marketplace** that was monitored.
 
@@ -231,13 +244,14 @@ columns:
   equivalent**: either drop these columns or show `—` in them. Never map a shop
   tier onto a seller medal
 
-Do **not** put a delta symbol or "(Δ)" in any column header — it confuses sellers;
-the change belongs inside the cell. Below the table, state the period actually
-compared (for example "today versus seven days ago"). On Mercado Livre also
-surface any baseline date that was not exactly the target, so the comparison is
-transparent; on Shopee, when the carried-forward record is older than the target
-day, give its date and say the value simply had not changed since. You may
-translate the column headers into the seller's language.
+Do **not** put a delta symbol or "(Δ)" in any column header — it confuses
+sellers; the change belongs inside the cell. Below the table, state the period
+actually compared (for example "today versus seven days ago"). On Mercado Livre
+also surface any baseline date that was not exactly the target, so the
+comparison is transparent; on Shopee, when the carried-forward record is older
+than the target day, give its date and say the value simply had not changed
+since. You may translate the column headers into the language of the seller's
+request.
 
 **Disclaimer (every report) — use the variant for the marketplace you queried.**
 

--- a/skills/pulse-find-exact-same-product/SKILL.md
+++ b/skills/pulse-find-exact-same-product/SKILL.md
@@ -69,7 +69,11 @@ JoomPulse MCP setup before it can search or compare products.
   includes only items with at least one lifetime sale, and brand is recorded for
   tracked items only.
 - **Read-only.** The skill does not sign in as the seller or modify any listing.
-- **Language:** detect the seller's language and respond in it. Default to pt-BR.
+- **Language:** write in the language of the message you are answering, and
+  default to pt-BR only when that is unclear. Never infer the language from the
+  store, its listings or the marketplace — those are Brazilian whatever
+  language the seller writes in, so a seller who asks in English gets the whole
+  report in English.
 - **Keep the workflow invisible.** The seller wants the answer, not a play-by-
   play. If one approach does not return data, switch to another quietly; only if
   every approach fails do you say one short, friendly sentence.
@@ -194,9 +198,9 @@ numbers.
 
 ## Output Format
 
-Respond in the seller's language. Lead with a short line naming the
-**marketplace** and the reference product. Use a concise table when there are
-multiple candidates:
+Respond in the language of the seller's request. Lead with a short line naming
+the **marketplace** and the reference product. Use a concise table when there
+are multiple candidates:
 
 | Result | Product | Link | Why it matches |
 | --- | --- | --- | --- |

--- a/skills/seller-copilot/SKILL.md
+++ b/skills/seller-copilot/SKILL.md
@@ -94,7 +94,10 @@ MCP setup before it can analyse marketplace data.
 - **Not available from JoomPulse:** supplier or landed cost, true unit cost, return and
   refund rates, and traffic or conversion funnels. If the question depends on one of these,
   say so and ask the seller to supply the figure — do not estimate it silently.
-- **Match the seller's language.** One language per answer, no mixing.
+- **Match the language of the seller's request.** One language per answer, no
+  mixing, and never infer the language from the store or its listings — those are
+  Brazilian whatever language the seller writes in. When the request is in English,
+  no Portuguese is left anywhere in the answer.
 
 ## How to use this skill
 
@@ -323,8 +326,9 @@ be read all at once. Files prefixed `shopee-` are Shopee Brasil; the rest are Me
 - **One-line caption above every table**, saying what it shows — scope, sort order, and
   snapshot date.
 - **Verdict before table**, always.
-- **Portuguese column labels** with the prose in the seller's language: `Vendas estimadas`,
-  `Receita estimada`, `Preço`, `Oportunidade`, `Monopolização`, `Tendência`.
+- **Portuguese column labels** with the prose in the language of the seller's
+  request: `Vendas estimadas`, `Receita estimada`, `Preço`, `Oportunidade`,
+  `Monopolização`, `Tendência`.
 - **Top 10 rows by default** (all, if fewer than 10). When more exist, **state the total
   and offer the rest or a CSV** — never truncate silently. Equally, **never pad a list to
   reach the requested count**: if the seller asked for 10 and the data yields 6, return 6
@@ -342,6 +346,14 @@ be read all at once. Files prefixed `shopee-` are Shopee Brasil; the rest are Me
 - Where a score is expressed as "percent of competitors better than you", state that
   **lower means you are ahead**, and that it is relative to the competitor set rather than
   an absolute grade.
+
+The column headers, labels and disclaimers below are written in pt-BR because
+that is the default. They are a template, not literal strings: when the seller
+writes in another language, translate all of them — the headers, row values
+such as `sim` / `não` / `ouro`, and the disclaimer — and keep the structure,
+the emoji and the `R$` money formatting, which stays the same in every language
+because the marketplace trades in reais. When the request is in English, no
+Portuguese is left anywhere in the answer.
 
 ## Notes and guardrails
 

--- a/skills/seller-overview-tracker/SKILL.md
+++ b/skills/seller-overview-tracker/SKILL.md
@@ -68,8 +68,11 @@ JoomPulse MCP setup before it can monitor a seller.
 - **Read-only.** The skill never signs in as the seller or modifies a listing; it
   does not store the snapshot — the user keeps the downloadable table and brings it
   back next period.
-- **Language:** respond in pt-BR by default; mirror another language only if the
-  user clearly uses it.
+- **Language:** write in the language of the message you are answering, and
+  default to pt-BR only when that is unclear. Never infer the language from the
+  store, its listings or the marketplace — those are Brazilian whatever
+  language the seller writes in, so a seller who asks in English gets the whole
+  report in English.
 - **The baseline is user-supplied.** Never claim a change without a previous table
   to compare against, and never infer or fabricate one from memory. The previous
   table must be for the **same seller on the same marketplace**.
@@ -170,8 +173,17 @@ own and the user is told to save it for next time.
 
 ## Output
 
-Respond in pt-BR by default. Present the result with no commentary about how it was
-produced. Lead with a short line naming the **marketplace** and the store.
+Respond in the language of the seller's request, default pt-BR. Present the
+result with no commentary about how it was produced. Lead with a short line
+naming the **marketplace** and the store.
+
+The column headers, labels and disclaimers below are written in pt-BR because
+that is the default. They are a template, not literal strings: when the seller
+writes in another language, translate all of them — the headers, row values
+such as `sim` / `não` / `ouro`, and the disclaimer — and keep the structure,
+the emoji and the `R$` money formatting, which stays the same in every language
+because the marketplace trades in reais. When the request is in English, no
+Portuguese is left anywhere in the answer.
 
 **Snapshot (always):** a markdown table `| Campo | Valor atual |` for the rows
 below, plus a downloadable `.csv` / `.xlsx` of the same data.

--- a/skills/top-brand-position-tracker/SKILL.md
+++ b/skills/top-brand-position-tracker/SKILL.md
@@ -65,8 +65,11 @@ JoomPulse MCP setup before it can rank brands and track their positions.
   and brings it back next period.
 - **The baseline is user-supplied.** Never claim a position change without a
   previous table to compare against, and never infer or fabricate one from memory.
-- **Language:** respond in pt-BR by default. If the seller clearly writes in
-  another language, mirror it; otherwise pt-BR.
+- **Language:** write in the language of the message you are answering, and
+  default to pt-BR only when that is unclear. Never infer the language from the
+  store, its listings or the marketplace — those are Brazilian whatever
+  language the seller writes in, so a seller who asks in English gets the whole
+  report in English.
 - **Keep the workflow invisible.** The seller wants the ranking, not a play-by-
   play. If one approach does not return data, switch to another quietly; only if
   every approach fails do you say one short, friendly sentence.
@@ -129,8 +132,9 @@ on its own (no movement column) and the user is told to save it for next time.
 
 ## Output
 
-Respond in the seller's language (pt-BR by default), with no commentary about how
-the result was produced. Use plain markdown so it renders cleanly in any client.
+Respond in the language of the seller's request (pt-BR by default), with no
+commentary about how the result was produced. Use plain markdown so it renders
+cleanly in any client.
 
 There is **one canonical brand-ranking table**, used everywhere (in the response
 text and mirrored by the downloadable file). One row per brand, sorted by current
@@ -214,8 +218,16 @@ the response text, never inside a rendered visual.
 ### Ranked table (always markdown, both surfaces)
 
 The ranked table is the **one canonical brand-ranking table defined in Output** —
-the same columns, in pt-BR, on every surface. It lives in the response text, never
-inside a rendered visual.
+the same columns on every surface. It lives in the response text, never inside
+a rendered visual.
+
+The column headers, labels and disclaimers below are written in pt-BR because
+that is the default. They are a template, not literal strings: when the seller
+writes in another language, translate all of them — the headers, row values
+such as `sim` / `não` / `ouro`, and the disclaimer — and keep the structure,
+the emoji and the `R$` money formatting, which stays the same in every language
+because the marketplace trades in reais. When the request is in English, no
+Portuguese is left anywhere in the answer.
 
 - **Standalone ranking:** columns `Posição | Marca | GMV estimado (semana) |
   Vendas est. (semana) | Anúncios | Avaliações | Preço médio` — **no `Variação`

--- a/skills/top-keywords-in-my-category/SKILL.md
+++ b/skills/top-keywords-in-my-category/SKILL.md
@@ -49,7 +49,11 @@ JoomPulse MCP setup before it can list a category's keywords.
   counts come from Mercado Livre search trends — say so; do not add the sales
   estimate disclaimer that other skills use.
 - **Read-only.** The skill never writes or modifies anything.
-- **Language:** detect the seller's language and respond in it. Default to pt-BR.
+- **Language:** write in the language of the message you are answering, and
+  default to pt-BR only when that is unclear. Never infer the language from the
+  store, its listings or the marketplace — those are Brazilian whatever
+  language the seller writes in, so a seller who asks in English gets the whole
+  report in English.
 - **Keep the workflow invisible.** Show `—` for any missing value; never fabricate.
 
 ## Workflow
@@ -66,9 +70,16 @@ rank and its competing-product count. Sort by rank, best position first.
 
 ## Output
 
-Respond in the seller's language (default pt-BR). The keywords always render as a
-markdown table, sorted by position. The headers below are the pt-BR default and
-may be rendered in the seller's language:
+Respond in the language of the seller's request (default pt-BR). The keywords
+always render as a markdown table, sorted by position.
+
+The column headers, labels and disclaimers below are written in pt-BR because
+that is the default. They are a template, not literal strings: when the seller
+writes in another language, translate all of them — the headers, row values
+such as `sim` / `não` / `ouro`, and the disclaimer — and keep the structure,
+the emoji and the `R$` money formatting, which stays the same in every language
+because the marketplace trades in reais. When the request is in English, no
+Portuguese is left anywhere in the answer.
 
 | Posição | Palavra-chave | Produtos (oferta) |
 |--:|---|--:|

--- a/skills/top-sellers-in-category/SKILL.md
+++ b/skills/top-sellers-in-category/SKILL.md
@@ -56,7 +56,11 @@ JoomPulse MCP setup before it can rank a category's sellers.
   are real history. Disclose the estimate caveat in every output.
 - **Read-only.** The skill never writes or modifies anything; it does not store the
   leaderboard — the user keeps the downloadable table and brings it back next period.
-- **Language:** detect the seller's language and respond in it. Default to pt-BR.
+- **Language:** write in the language of the message you are answering, and
+  default to pt-BR only when that is unclear. Never infer the language from the
+  store, its listings or the marketplace — those are Brazilian whatever
+  language the seller writes in, so a seller who asks in English gets the whole
+  report in English.
 - **The baseline is user-supplied.** Never claim a movement without a previous
   leaderboard to compare against, and never infer or fabricate one from memory.
 
@@ -96,7 +100,15 @@ leaderboard. The change column header is a word ("Variação"), never a bare "Δ
 
 ## Output
 
-Respond in the seller's language (default pt-BR).
+Respond in the language of the seller's request (default pt-BR).
+
+The column headers, labels and disclaimers below are written in pt-BR because
+that is the default. They are a template, not literal strings: when the seller
+writes in another language, translate all of them — the headers, row values
+such as `sim` / `não` / `ouro`, and the disclaimer — and keep the structure,
+the emoji and the `R$` money formatting, which stays the same in every language
+because the marketplace trades in reais. When the request is in English, no
+Portuguese is left anywhere in the answer.
 
 **Leaderboard (always):** a markdown table, plus a downloadable `.csv` / `.xlsx`:
 

--- a/skills/unbranded-products-in-category/SKILL.md
+++ b/skills/unbranded-products-in-category/SKILL.md
@@ -60,7 +60,11 @@ JoomPulse MCP setup before it can find unbranded products.
   disclaimer.
 - **Read-only.** The skill never writes or modifies anything, and does not render
   product images.
-- **Language:** detect the seller's language and respond in it. Default to pt-BR.
+- **Language:** write in the language of the message you are answering, and
+  default to pt-BR only when that is unclear. Never infer the language from the
+  store, its listings or the marketplace — those are Brazilian whatever
+  language the seller writes in, so a seller who asks in English gets the whole
+  report in English.
 - **Keep the workflow invisible.** Show `—` for any missing value; never fabricate.
 
 **Shopee data — what differs from Mercado Livre**
@@ -140,10 +144,18 @@ strongest ~20–30.
 
 ## Output
 
-Respond in the seller's language (default pt-BR). Lead with a one-line summary (the
-**marketplace**, the category and how many unbranded products were found), sort by
-estimated demand, and end with the disclaimer. The product list always renders as a
-markdown table.
+Respond in the language of the seller's request (default pt-BR). Lead with a
+one-line summary (the **marketplace**, the category and how many unbranded
+products were found), sort by estimated demand, and end with the disclaimer.
+The product list always renders as a markdown table.
+
+The column headers, labels and disclaimers below are written in pt-BR because
+that is the default. They are a template, not literal strings: when the seller
+writes in another language, translate all of them — the headers, row values
+such as `sim` / `não` / `ouro`, and the disclaimer — and keep the structure,
+the emoji and the `R$` money formatting, which stays the same in every language
+because the marketplace trades in reais. When the request is in English, no
+Portuguese is left anywhere in the answer.
 
 **Product table (Mercado Livre):**
 

--- a/skills/uncontested-niche-finder/SKILL.md
+++ b/skills/uncontested-niche-finder/SKILL.md
@@ -75,7 +75,11 @@ JoomPulse MCP setup before it can find uncontested niches.
   historical listing data, on Shopee from the marketplace's own rounded sold
   counters refined with review movement. Use the matching disclaimer.
 - **Read-only.** The skill does not sign in as the seller or modify any listing.
-- **Language:** detect the seller's language and respond in it. Default to pt-BR.
+- **Language:** write in the language of the message you are answering, and
+  default to pt-BR only when that is unclear. Never infer the language from the
+  store, its listings or the marketplace — those are Brazilian whatever
+  language the seller writes in, so a seller who asks in English gets the whole
+  report in English.
 - **Keep the workflow invisible.** The seller wants the niches, not a play-by-
   play. If one approach does not return data, switch to another quietly; only if
   every approach fails do you say one short, friendly sentence. Never fill gaps
@@ -201,9 +205,17 @@ numbers.
 
 ## Output
 
-Respond in the seller's language. Present the result with no commentary about how
-it was produced. The product table always renders as markdown so it reads
-cleanly in any client.
+Respond in the language of the seller's request. Present the result with no
+commentary about how it was produced. The product table always renders as
+markdown so it reads cleanly in any client.
+
+The column headers, labels and disclaimers below are written in pt-BR because
+that is the default. They are a template, not literal strings: when the seller
+writes in another language, translate all of them — the headers, row values
+such as `sim` / `não` / `ouro`, and the disclaimer — and keep the structure,
+the emoji and the `R$` money formatting, which stays the same in every language
+because the marketplace trades in reais. When the request is in English, no
+Portuguese is left anywhere in the answer.
 
 Lead with a short intro line naming the **marketplace** and the category — and on
 Shopee, the category level you actually worked at.
@@ -257,9 +269,9 @@ heading.
 Put the marketplace link on the product identifier in each row. When a cell is
 empty, show `—` rather than guessing. Below the table, briefly state what
 "uncontested niche" means here: sub-categories deeper than the third level that
-have **no platinum seller at all** among their listings on Mercado Livre, or **no
-Official store (Shopee Mall) seller at all** on Shopee. You may translate the
-column headers into the seller's language.
+have **no platinum seller at all** among their listings on Mercado Livre, or
+**no Official store (Shopee Mall) seller at all** on Shopee. You may translate
+the column headers into the language of the seller's request.
 
 **On Shopee, state this next to the verdict itself, not only in the guardrails:**
 only items with at least one lifetime sale are tracked, so an Official store


### PR DESCRIPTION
Every skill said to respond in **the seller's language**, defaulting to pt-BR. In any deployment where the assistant works *for* a Brazilian store, that phrase resolves to the store — so a seller writing in English received the entire report in Portuguese: headers, row values, disclaimer, everything, while the assistant's own surrounding prose stayed English. It reads as a bug, and it is the first thing a non-Portuguese user hits.

Three layers, because the first fix alone was not enough in testing:

**1. Name the request.** "Respond in the seller's language" becomes "respond in the language of the seller's **request**", plus an explicit *never infer the language from the store, its listings or the marketplace — those are Brazilian whatever language the seller writes in*. That is the root cause; the rest is reinforcement.

**2. Say the pt-BR templates are patterns.** Most skills carry their report template with Portuguese headers and row values, which read as literal strings to copy. Each affected skill now states they are a template to translate — headers, row values like `sim` / `não` / `ouro`, and the disclaimer — while keeping the structure, the emoji, and `R$` formatting, which stays the same in every language because the marketplace trades in reais.

**3. Make it checkable.** *"When the request is in English, no Portuguese is left anywhere in the answer."* In testing, descriptive guidance ("respond in their language") was followed inconsistently; a checkable statement the model can verify against its own output was not.

Verified against the live connector: the same question that previously returned a fully Portuguese report returned a fully English one, repeatably.

**Reviewing this:** it is 18 files but one change repeated. Read `pulse-find-exact-same-product` — the smallest slice, essentially one line — then scan the rest for the same shape. `seller-copilot` is included; it had received only half the rule.

No behaviour changes for a seller writing in Portuguese, which remains the default.
