### PR TITLE
Offer a downloadable file only where the client can produce one

### DIFF
--- a/skills/category-monitor/SKILL.md
+++ b/skills/category-monitor/SKILL.md
@@ -158,10 +158,12 @@ Two Shopee-specific cautions:
 
 Render the snapshot table for **today**, headed with the marketplace, the
 category name and the date — and, on Shopee, the month the aggregates cover.
-This table is the deliverable — and **offer it as a downloadable file (`.csv` /
-`.xlsx`)** so the user can save it and bring it back next period as the
-baseline. On a standalone snapshot there is **no change column and no color-dot
-legend** — just metric and current value.
+This table is the deliverable. **Where the client can produce files, also offer
+it as a downloadable `.csv` / `.xlsx`** so the user can save it and bring it
+back next period as the baseline; where it cannot, the markdown table stands on
+its own — never offer a download you cannot deliver. On a standalone snapshot
+there is **no change column and no color-dot legend** — just metric and current
+value.
 
 ### Step 4 — Offer comparison, and compare if a previous table is supplied
 
@@ -183,8 +185,9 @@ an incomplete month.
 Respond in the seller's language (default pt-BR). Name the marketplace the
 figures came from.
 
-**Snapshot (always):** a markdown table `| Métrica | Valor atual |`, plus a
-downloadable `.csv` / `.xlsx` of the same data.
+**Snapshot (always):** a markdown table `| Métrica | Valor atual |`, plus —
+where the client can produce files — a downloadable `.csv` / `.xlsx` of the
+same data.
 
 - **Mercado Livre** rows: **Vendas (estimadas), Produtos, Produtos de catálogo,
   Vendedores, Distribuição de medalhas, Monopolização**.

--- a/skills/ml-product-analysis/SKILL.md
+++ b/skills/ml-product-analysis/SKILL.md
@@ -315,10 +315,11 @@ Shopee:
 > histórico são rastreados, então esta lista é um piso. Preço, classificação e
 > avaliações são histórico real da Shopee.
 
-**Download** — offer a downloadable spreadsheet (`.xlsx` plus `.csv`) of the
-subject and analogs. On Mercado Livre give separate Mercado Livre and JoomPulse
-link columns so the seller can see the source of every product's data; on Shopee
-give the item and shop link columns instead, and use the Shopee column set.
+**Download** — where the client can produce files, offer a downloadable
+spreadsheet (`.xlsx` plus `.csv`) of the subject and analogs. On Mercado Livre
+give separate Mercado Livre and JoomPulse link columns so the seller can see
+the source of every product's data; on Shopee give the item and shop link
+columns instead, and use the Shopee column set.
 
 ## Notes & Guardrails
 

--- a/skills/product-change-monitor/SKILL.md
+++ b/skills/product-change-monitor/SKILL.md
@@ -260,8 +260,8 @@ Shopee:
 > avaliações são histórico real da Shopee, e esse histórico começa em maio de
 > 2026.
 
-**Download** — offer a downloadable spreadsheet (`.xlsx` plus `.csv`) of the
-change table.
+**Download** — where the client can produce files, offer a downloadable
+spreadsheet (`.xlsx` plus `.csv`) of the change table.
 
 ## Notes & Guardrails
 

--- a/skills/seller-overview-tracker/SKILL.md
+++ b/skills/seller-overview-tracker/SKILL.md
@@ -148,12 +148,14 @@ numbers.
 ### Step 2 — Present today's snapshot and offer it for download
 
 Lay out the snapshot fields as a table, headed with the store name, the
-**marketplace** and the date. This table is the deliverable — and **offer it as a
-downloadable file (`.csv` / `.xlsx`)** so the user can save it and bring it back
-next period as the baseline. If any field comes back empty, show `—`; never
-substitute a guess. On Mercado Livre add the JoomPulse seller dashboard link; on
-Shopee link the shop on Shopee instead — **there is no JoomPulse dashboard link
-for Shopee**, so never invent one. On a standalone snapshot there is **no change
+**marketplace** and the date. This table is the deliverable. **Where the client
+can produce files, also offer it as a downloadable `.csv` / `.xlsx`** so the
+user can save it and bring it back next period as the baseline; where it
+cannot, the markdown table stands on its own — never offer a download you
+cannot deliver. If any field comes back empty, show `—`; never substitute a
+guess. On Mercado Livre add the JoomPulse seller dashboard link; on Shopee link
+the shop on Shopee instead — **there is no JoomPulse dashboard link for
+Shopee**, so never invent one. On a standalone snapshot there is **no change
 column and no color-dot legend** — just field and current value.
 
 ### Step 3 — Offer comparison, and compare if a previous table is supplied
@@ -174,7 +176,8 @@ Respond in pt-BR by default. Present the result with no commentary about how it 
 produced. Lead with a short line naming the **marketplace** and the store.
 
 **Snapshot (always):** a markdown table `| Campo | Valor atual |` for the rows
-below, plus a downloadable `.csv` / `.xlsx` of the same data.
+below, plus — where the client can produce files — a downloadable `.csv` /
+`.xlsx` of the same data.
 
 **Snapshot / comparison rows (Mercado Livre)** — pt-BR labels:
 

--- a/skills/top-brand-position-tracker/SKILL.md
+++ b/skills/top-brand-position-tracker/SKILL.md
@@ -105,10 +105,11 @@ JoomPulse MCP setup before it can rank brands and track their positions.
 ### Step 2 — Present today's ranking and offer it for download
 
 Render today's brand-ranking table (head it with the category name and the date).
-This table is the deliverable — and **offer it as a downloadable file (`.csv` /
-`.xlsx`)** so the user can save it and bring it back next period as the baseline.
-On a standalone ranking there is **no movement column and no legend** — just the
-ranking.
+This table is the deliverable. **Where the client can produce files, also offer
+it as a downloadable `.csv` / `.xlsx`** so the user can save it and bring it
+back next period as the baseline; where it cannot, the markdown table stands on
+its own — never offer a download you cannot deliver. On a standalone ranking
+there is **no movement column and no legend** — just the ranking.
 
 ### Step 3 — Offer comparison, and compare if a previous table is supplied
 

--- a/skills/top-sellers-in-category/SKILL.md
+++ b/skills/top-sellers-in-category/SKILL.md
@@ -76,9 +76,11 @@ as a cap — show fewer if fewer exist.
 ### Step 3 — Present today's leaderboard and offer it for download
 
 Render the leaderboard for **today** (head it with the category name and the date).
-This table is the deliverable — and **offer it as a downloadable file (`.csv` /
-`.xlsx`)** so the user can save it and bring it back next period as the baseline.
-On a standalone leaderboard there is **no movement column and no legend**.
+This table is the deliverable. **Where the client can produce files, also offer
+it as a downloadable `.csv` / `.xlsx`** so the user can save it and bring it
+back next period as the baseline; where it cannot, the markdown table stands on
+its own — never offer a download you cannot deliver. On a standalone
+leaderboard there is **no movement column and no legend**.
 
 ### Step 4 — Offer comparison, and compare if a previous leaderboard is supplied
 
@@ -98,7 +100,8 @@ leaderboard. The change column header is a word ("Variação"), never a bare "Δ
 
 Respond in the seller's language (default pt-BR).
 
-**Leaderboard (always):** a markdown table, plus a downloadable `.csv` / `.xlsx`:
+**Leaderboard (always):** a markdown table, plus — where the client can produce
+files — a downloadable `.csv` / `.xlsx`:
 
 | Vendedor | Vendas méd. (mês) | Receita média (mês) | Vendas 365d | Cancel rate | Sales trend | Marcas | Produtos (todos) | Produtos (com venda) | Envio internacional | Classic | Premium |
 |---|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|


### PR DESCRIPTION
Six skills promise the user a downloadable `.csv` / `.xlsx` unconditionally — *"This table is the deliverable — and **offer it as a downloadable file**"*. Whether that is possible depends entirely on the client. Where it is not, the skill instructs the assistant to promise a file it cannot deliver, and the user is left waiting for a download that never arrives.

The offer is now conditional:

> *Where the client can produce files, also offer it as a downloadable `.csv` / `.xlsx` so the user can save it and bring it back next period as the baseline; where it cannot, the markdown table stands on its own — never offer a download you cannot deliver.*

Nothing changes for a client that can produce files. For one that cannot, the markdown table is stated as the deliverable in its own right — which matters most for the tracker skills, since the saved table is what the user pastes back next period for a comparison.

Found running these skills in a deployment with no file output, where every run ended by offering a spreadsheet that could not exist.
