### PR TITLE
Mark the monthly sales trend as an estimate, and drop the seller's JoomPulse link

### DIFF
--- a/skills/seller-overview-tracker/SKILL.md
+++ b/skills/seller-overview-tracker/SKILL.md
@@ -60,8 +60,11 @@ JoomPulse MCP setup before it can monitor a seller.
 - **Sales and revenue are JoomPulse estimates** — estimated monthly revenue,
   estimated monthly sales, average ticket, and average price are not real
   transactions. Disclose this in every output.
-  - **On Mercado Livre**, by contrast, the rolling 60-day and 365-day sales counts,
-    the sales trend, and the cancellation rate are real Mercado Livre data.
+  - **On Mercado Livre**, by contrast, the rolling 60-day and 365-day sales counts
+    and the cancellation rate are real Mercado Livre data. **The monthly sales trend
+    is not.** It is the month-over-month change in JoomPulse's estimated sales, so it
+    carries the estimate caveat like every other estimated figure — never list it
+    among the real ones.
   - **On Shopee every sales figure is an estimate** — there is no real-data
     counterpart, so the Mercado Livre sentence above must never appear in a Shopee
     output. Only price, the buyer rating and the review count are real.
@@ -191,7 +194,8 @@ below, plus a downloadable `.csv` / `.xlsx` of the same data.
 - Reputação (5 verde, a melhor … 1 vermelho, a pior)
 - Ticket médio / preço médio
 - Localização (cidade, estado, país)
-- Link JoomPulse do vendedor
+- Sem link — **sellers have no JoomPulse dashboard page**, so never build one
+  from a shopId
 
 **Snapshot / comparison rows (Shopee)** — same shape, with the marketplace's own
 fields:
@@ -216,8 +220,8 @@ fields:
   colour ladder. Say so explicitly rather than presenting them as the same field
 - Ticket médio / preço médio
 - Localização
-- Link da loja na Shopee — **there is no JoomPulse dashboard link for Shopee**, so
-  never invent one
+- Link da loja na Shopee — **there is no JoomPulse dashboard link for Shopee**
+  either, so never invent one
 
 For the three rows with **no Shopee equivalent at all** — cancellation rate, sales
 over the last 60 days and sales over the last 365 days — show `—` and state plainly


### PR DESCRIPTION
Two corrections found running this skill against the live connector.

**The monthly sales trend is an estimate, not real Mercado Livre data.** The skill lists "the sales trend" among the real MeLi figures alongside the 60- and 365-day counts. That was accurate for `salesTrend`, the API run-rate derived from completed-sale counts — but `pulse://rules` AP-8 forbids using that field as a seller's trend (NULL for roughly 82% of sellers) and directs every client to `MlbSellersSnapshot.monthlySalesGrowth`, which is the month-over-month change in JoomPulse's *estimated* sales. The field changed; the disclaimer did not. A live run told a seller its −7,0% momentum was verified Mercado Livre data.

**Sellers have no JoomPulse page.** The snapshot row list asks for "Link JoomPulse do vendedor". `pulse://overview` rule 10 restricts the `beginner-products/{id}` template to listing ids and skips seller grain, so any URL built from a `shopId` 404s. The Shopee bullet below now reads "no JoomPulse dashboard link for Shopee **either**", so it no longer implies Mercado Livre has one.

No behavioural change beyond those two lines.
