### PR TITLE
Drop the category's JoomPulse link: categories have no JoomPulse page

### DIFF
--- a/skills/top-brand-position-tracker/SKILL.md
+++ b/skills/top-brand-position-tracker/SKILL.md
@@ -160,7 +160,8 @@ In the `Variação` cell (comparison only), mark each brand:
 
 The change column header is the **word `Variação`** — never a bare delta symbol.
 
-Below the table, include the category's **JoomPulse link**. On a comparison, state
+A category has no JoomPulse page, so the table carries no category link — never
+build one from a categoryId. On a comparison, state
 the period being compared (for example *"Comparado com a tabela de 12/06"*). On a
 standalone ranking, invite the user to save the table and send it back next period
 to see how positions moved.


### PR DESCRIPTION
The skill asks for the category's JoomPulse link below the table. `pulse://overview` rule 10 restricts the `beginner-products/{id}` template to listing ids and skips category grain, so a URL built from a `categoryId` resolves to nothing.

Found running the skill against the live connector: every generated category link was dead.

**One thing this PR deliberately leaves alone.** Line 250 mandates rounded money (`R$ 1,2 mi` / `R$ 850 mil`), while `pulse://overview` §3.5 and §6 rule 4 say never to round BRL — *"Render currency as R$ 570.261,40 … Never R$ 570k."* Those contradict, and the assistant currently follows the skill. It looks like a deliberate choice for a ranking table, so it is worth settling separately rather than changing here.
