### PR TITLE
[Merge first] Stop linking seller names to a JoomPulse page that does not exist

### DIFF
--- a/skills/top-sellers-in-category/SKILL.md
+++ b/skills/top-sellers-in-category/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Ranks the top sellers in one Mercado Livre (Brasil) category by estimated average monthly
   revenue via JoomPulse, and returns a downloadable leaderboard — per seller: estimated
   monthly sales and revenue, 365-day completed sales, cancellation rate, sales trend, brands,
-  product counts, international shipping, and listing-type counts, with a JoomPulse link each.
+  product counts, international shipping, and listing-type counts.
   It can also track how the ranking moved: supply a previous-period leaderboard for the same
   category and it shows each seller's movement (rose / fell / new) plus the biggest movers.
   Triggers: "top sellers in this category", "biggest stores in a category", "rank sellers by
@@ -103,7 +103,9 @@ Respond in the seller's language (default pt-BR).
 | Vendedor | Vendas méd. (mês) | Receita média (mês) | Vendas 365d | Cancel rate | Sales trend | Marcas | Produtos (todos) | Produtos (com venda) | Envio internacional | Classic | Premium |
 |---|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|
 
-- The **Vendedor** name links to the seller's JoomPulse page.
+- **The Vendedor name is plain text.** Sellers have no JoomPulse page — the
+  dashboard link template is for listing ids only — so a URL built from a shopId
+  404s.
 
 **Comparison (only when a previous leaderboard is supplied):** the same table plus
 a **Variação** column, and a **Destaques** block (maiores altas / maiores quedas).


### PR DESCRIPTION
> **Merge this before #35.** #35 contains this commit, merged in to resolve a clash on the same passages. Landing this one first keeps #35's diff to its own work. If #35 lands first, it must use a merge commit rather than squash — a squash rewrites the SHA, so git replays this diff against changed text and conflicts even though the content is already in `main`.

The **Vendedor** name linked to a seller's JoomPulse page. Sellers have no such page: the dashboard link template is for listing ids only, so a URL built from a shopId 404s.

The name is now plain text, and the skill's description no longer promises a link per seller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)